### PR TITLE
Add design-sync inputs for the lookwhatibuilt.today Claude Design project

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,66 @@
+# design-sync notes — @misterbeardy/design-system
+
+Target Claude Design project: **lookwhatibuilt.today** (`38437aad-2039-4a1a-ad1d-73b3aeb3cec2`).
+Shape: **package** (no Storybook). 11 components, all authored previews, all graded good.
+
+## Repo-specific setup (the gotchas that cost time — do these before the converter)
+
+- **No lockfile, no `node_modules`, `react` is a peerDep.** Install build deps into the
+  repo's own `node_modules` WITHOUT touching `package.json`:
+  `npm i --no-save react react-dom @types/react`. Point the converter at
+  `--node-modules ./node_modules`. `@types/react` MUST sit next to the repo's `.d.ts`
+  files or ts-morph resolves React utility types to `any` → empty prop bodies +
+  `[ZERO_MATCH]`.
+- **Component discovery can't use the `.d.ts` entry.** The package declares no
+  `types`/`exports.*.types` and its type entry lives at `components/core/index.d.ts`,
+  so `findTypesRoot` never locates it → `[ZERO_MATCH] no component exports`. Fixed by
+  enumerating all 11 components in `cfg.componentSrcMap` (pins each to its
+  `components/core/<Name>.jsx`). **When a component is added, add it to BOTH
+  `componentSrcMap` and `docsMap`** — discovery won't auto-find it.
+- **In-repo tokens need a self-symlink.** `copyTokens` only copies from a package in
+  `node_modules`, and `tokensGlob` alone is a no-op without `tokensPkg`. We symlink the
+  DS into its own node_modules so `tokensPkg` resolves:
+  `mkdir -p node_modules/@misterbeardy && ln -sfn ../.. node_modules/@misterbeardy/design-system`.
+  Then `cfg.tokensPkg="@misterbeardy/design-system"` + `cfg.tokensGlob="tokens/*.css"`
+  copy the 5 token files. **This symlink is gitignored — recreate it on a fresh clone.**
+- **`cssEntry` is `components/core/core.css`** (the real component stylesheet → `_ds_bundle.css`),
+  NOT the repo's `styles.css` barrel. Pointing it at the barrel copies the barrel's
+  `@import "./tokens/..."` lines into `_ds_bundle.css` at the bundle root where they
+  404 (`[CSS_IMPORT_MISSING]`). The generated `styles.css` rebuilds the closure
+  (tokens + `_ds_bundle.css`) correctly.
+- **Playwright:** cached chromium build `1228` ↔ playwright `1.61.1`. Install that exact
+  version into `.ds-sync/` or the render check fails with "Executable doesn't exist".
+
+## Decisions
+
+- **Docs = the repo's hand-authored `.prompt.md`.** Wired via `cfg.docsMap` (they end in
+  `.md` so they pass the doc-extension gate). This preserves the rich design intent;
+  the converter appends the synthesized `## Props` section. Far better than synthesizing.
+- **`Input` uses `cardMode: column`** (`cfg.overrides.Input`) — its 320px stories overflow
+  a grid cell otherwise (`[GRID_OVERFLOW]`).
+- **Fonts load remotely.** `typography.css` `@import`s Google Fonts (Space Grotesk +
+  JetBrains Mono) → `[FONT_REMOTE]`, non-blocking, assumed served at runtime. No local
+  fonts shipped, no `fonts/` dir.
+- **`guidelines/*.card.html` are NOT synced.** They're HTML reference cards, not the
+  markdown format `guidelinesGlob` copies, so `guidelines/` ships empty. Their design
+  guidance is captured in `conventions.md` + the per-component `.prompt.md`. Future
+  enhancement: convert them to markdown and set `cfg.guidelinesGlob`.
+
+## Known render warns
+
+- None. Render check is fully clean (11/11, bad 0, thin 0). `[FONT_REMOTE]` is the only
+  informational line and is expected (see above).
+
+## Re-sync risks (what can silently go stale)
+
+- **Per-clone setup is gitignored:** the `--no-save` react install AND the
+  `node_modules/@misterbeardy/design-system` self-symlink. Recreate both before running
+  `resync.mjs`, or the build fails at discovery/token-copy.
+- **`componentSrcMap`/`docsMap` are hand-enumerated** because discovery can't read the
+  types entry. A new component silently won't appear until added to both. (Best long-term
+  fix: add `"types": "./components/core/index.d.ts"` to the package, then discovery works
+  and these maps can shrink — not done here to avoid mutating tracked `package.json`.)
+- **Remote fonts** depend on Google Fonts being reachable at render time.
+- **Authored previews** in `.design-sync/previews/*.tsx` import from
+  `@misterbeardy/design-system` and are tied to the current component APIs (props like
+  `variant`, `tone`, `options`, `stats`). A breaking API change needs the preview updated.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -41,10 +41,15 @@ Shape: **package** (no Storybook). 11 components, all authored previews, all gra
 - **Fonts load remotely.** `typography.css` `@import`s Google Fonts (Space Grotesk +
   JetBrains Mono) → `[FONT_REMOTE]`, non-blocking, assumed served at runtime. No local
   fonts shipped, no `fonts/` dir.
-- **`guidelines/*.card.html` are NOT synced.** They're HTML reference cards, not the
-  markdown format `guidelinesGlob` copies, so `guidelines/` ships empty. Their design
-  guidance is captured in `conventions.md` + the per-component `.prompt.md`. Future
-  enhancement: convert them to markdown and set `cfg.guidelinesGlob`.
+- **Guidelines are synced as markdown.** The repo's original `guidelines/*.card.html`
+  are visual preview cards (not synced — they're HTML, not the markdown `guidelinesGlob`
+  copies). We hand-wrote markdown equivalents at `guidelines/*.md` (accent, neutrals,
+  status, spacing, radius, type-scale, grouped-list) capturing the real token values +
+  rules, and set `cfg.guidelinesGlob="guidelines/*.md"`. They land at
+  `guidelines/guidelines/*.md` in the bundle (the glob preserves the package-relative
+  subpath) with a generated `guidelines/index.md` — the double-nesting is cosmetic; the
+  index links resolve correctly. Keep the `.md` and `.card.html` in sync if the tokens
+  change; the `category:` frontmatter sets each card's group in the DS pane.
 
 ## Known render warns
 

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,39 @@
+{
+  "projectId": "38437aad-2039-4a1a-ad1d-73b3aeb3cec2",
+  "shape": "package",
+  "pkg": "@misterbeardy/design-system",
+  "globalName": "MisterBeardyDS",
+  "cssEntry": "components/core/core.css",
+  "tokensPkg": "@misterbeardy/design-system",
+  "tokensGlob": "tokens/*.css",
+  "componentSrcMap": {
+    "Button": "components/core/Button.jsx",
+    "Card": "components/core/Card.jsx",
+    "Chip": "components/core/Chip.jsx",
+    "Input": "components/core/Input.jsx",
+    "StatTile": "components/core/StatTile.jsx",
+    "Group": "components/core/Group.jsx",
+    "Row": "components/core/Row.jsx",
+    "GlyphTile": "components/core/GlyphTile.jsx",
+    "Segmented": "components/core/Segmented.jsx",
+    "Switch": "components/core/Switch.jsx",
+    "StatStrip": "components/core/StatStrip.jsx"
+  },
+  "docsMap": {
+    "Button": "components/core/Button.prompt.md",
+    "Card": "components/core/Card.prompt.md",
+    "Chip": "components/core/Chip.prompt.md",
+    "Input": "components/core/Input.prompt.md",
+    "StatTile": "components/core/StatTile.prompt.md",
+    "Group": "components/core/Group.prompt.md",
+    "Row": "components/core/Row.prompt.md",
+    "GlyphTile": "components/core/GlyphTile.prompt.md",
+    "Segmented": "components/core/Segmented.prompt.md",
+    "Switch": "components/core/Switch.prompt.md",
+    "StatStrip": "components/core/StatStrip.prompt.md"
+  },
+  "overrides": {
+    "Input": { "cardMode": "column" }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -35,5 +35,6 @@
   "overrides": {
     "Input": { "cardMode": "column" }
   },
-  "readmeHeader": ".design-sync/conventions.md"
+  "readmeHeader": ".design-sync/conventions.md",
+  "guidelinesGlob": "guidelines/*.md"
 }

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,74 @@
+# MisterBeardy Design System — how to build with it
+
+A small React kit (11 components) with a flat, calm, Apple-HIG-grouped-list
+visual language. Inline styles reading CSS custom properties — **no utility
+classes, no provider, no build step required.**
+
+## Setup (do this once)
+
+1. **Import the stylesheet.** Everything visual comes from `styles.css` and its
+   `@import` closure (`tokens/*.css` + `_ds_bundle.css`). Without it, components
+   render as unstyled boxes — the tokens they read are undefined.
+2. **Tint the page.** Set the app background to `var(--bg)` (a warm off-white
+   `#f6f5f3`, never pure white). The system is deliberately **flat — no
+   shadows**; depth comes entirely from the `--surface`/`--bg` contrast plus 1px
+   borders. A `Group` or `Card` on a white page looks like it's floating; the
+   fix is the page background, not a shadow.
+3. **Dark mode** is `[data-theme="dark"]` on a root element — every token has a
+   dark value. **No provider or ThemeProvider exists or is needed.**
+
+## The styling idiom: tokens, not classes
+
+Style your own layout glue with `var(--*)` tokens (in a `style` prop or your own
+CSS). Components carry their own look; you compose them and space them.
+
+| Group | Tokens |
+|---|---|
+| Surfaces | `--bg` `--surface` `--surface-alt` `--border` `--border-soft` `--hairline` |
+| Text | `--text-ink` `--text-muted` |
+| Accent slot (per-app) | `--accent` `--accent-soft` `--accent-text` |
+| Status (app-agnostic) | `--success[-soft/-text]` `--warning[-soft/-text]` `--danger[-soft/-text]` |
+| Fonts | `--font-display` (Space Grotesk), `--font-mono` (JetBrains Mono) |
+| Type shorthands | `--text-display` `--text-heading` `--text-subhead` `--text-body` `--text-section` `--text-row-label` `--text-row-sub` `--text-row-value` `--text-stat` `--text-stat-label` |
+| Spacing | `--space-1`…`--space-6` |
+| Radius | `--radius-sm` `--radius-md` `--radius-lg` `--radius-card` `--radius-pill` `--radius-xl` |
+| Tracking | `--tracking-caps` `--tracking-label` `--tracking-stat` |
+
+**The `--accent` is a slot** — each app overrides `--accent`/`--accent-soft`/
+`--accent-text` with its own hue; everything else is identical across apps.
+Status tokens are **never** overridden, so a "PAID" chip reads the same
+everywhere. Color lives on small elements (a `GlyphTile`, a `Chip`), never as a
+surface wash — that keeps color meaningful.
+
+## Idiom rules that keep designs on-brand
+
+- **Grouped lists are the default UX.** Related `Row`s live inside one `Group`;
+  the `Group` header is where the grouping earns its keep. Rows own their
+  padding so separators inset to the label edge — don't wrap rows in a padded div.
+- **`GlyphTile` carries color, needs an SVG icon** (never an emoji — the system
+  bans emoji in chrome). `tone` = semantic state; `color` = categorical data.
+- **`Switch`** is on/off *now* (track goes `--success`, not accent). **`Segmented`**
+  is "one of a few peers" (3–4 max). **`Chip`** is `mono` uppercase for status.
+- One headline metric per screen sets `accent` on `StatTile`/`StatStrip`.
+
+## Where the truth lives
+
+- `styles.css` → `tokens/*.css` (the token definitions) and `_ds_bundle.css`
+  (the few real selectors: Row separators, Switch, Segmented focus).
+- Per component: `components/core/<Name>/<Name>.prompt.md` (usage + intent, hand
+  written) and `<Name>.d.ts` (the props contract).
+
+## One idiomatic snippet
+
+```jsx
+import { Group, Row, GlyphTile, Switch } from '@misterbeardy/design-system';
+
+<div style={{ background: 'var(--bg)', padding: 'var(--space-5)' }}>
+  <Group header="Units" footer="Applies to every trip.">
+    <Row glyph={<GlyphTile tone="accent"><RulerIcon /></GlyphTile>}
+         label="Distance" value="Miles" chevron />
+    <Row label="Show chargers"
+         trailing={<Switch checked={on} onChange={setOn} label="Show chargers" />} />
+  </Group>
+</div>
+```

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@misterbeardy/design-system';
+
+export function Variants() {
+  return (
+    <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+      <Button variant="primary">Save changes</Button>
+      <Button variant="secondary">Cancel</Button>
+      <Button variant="soft">Add trip</Button>
+      <Button variant="ghost">Dismiss</Button>
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+    </div>
+  );
+}
+
+export function Disabled() {
+  return (
+    <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+      <Button variant="primary" disabled>Saving…</Button>
+      <Button variant="secondary" disabled>Cancel</Button>
+    </div>
+  );
+}

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,32 @@
+import { Card } from '@misterbeardy/design-system';
+
+export function Basic() {
+  return (
+    <Card style={{ maxWidth: 340 }}>
+      <div style={{ fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: 15, color: 'var(--text-ink)' }}>
+        Quote #1042
+      </div>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-muted)', marginTop: 6 }}>
+        Sent 2 days ago · $128.40
+      </div>
+    </Card>
+  );
+}
+
+export function Panel() {
+  return (
+    <Card style={{ maxWidth: 340, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div style={{ fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: 15, color: 'var(--text-ink)' }}>
+        Trip summary
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--text-muted)' }}>
+        <span>Distance</span>
+        <span style={{ color: 'var(--text-ink)', fontVariantNumeric: 'tabular-nums' }}>546 mi</span>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--text-muted)' }}>
+        <span>Drive time</span>
+        <span style={{ color: 'var(--text-ink)', fontVariantNumeric: 'tabular-nums' }}>8h 27m</span>
+      </div>
+    </Card>
+  );
+}

--- a/.design-sync/previews/Chip.tsx
+++ b/.design-sync/previews/Chip.tsx
@@ -1,0 +1,23 @@
+import { Chip } from '@misterbeardy/design-system';
+
+export function Tones() {
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+      <Chip tone="neutral">DRAFT</Chip>
+      <Chip tone="accent">SENT</Chip>
+      <Chip tone="success">PAID</Chip>
+      <Chip tone="warning">PENDING</Chip>
+      <Chip tone="danger">OVERDUE</Chip>
+      <Chip tone="ink">ARCHIVED</Chip>
+    </div>
+  );
+}
+
+export function DisplayTags() {
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <Chip mono={false} tone="neutral">Road trips</Chip>
+      <Chip mono={false} tone="accent">Featured</Chip>
+    </div>
+  );
+}

--- a/.design-sync/previews/GlyphTile.tsx
+++ b/.design-sync/previews/GlyphTile.tsx
@@ -1,0 +1,41 @@
+import { GlyphTile } from '@misterbeardy/design-system';
+
+const S = { width: 13, height: 13, fill: 'none', stroke: 'currentColor', strokeWidth: 1.75, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const };
+
+const Pin = () => (
+  <svg viewBox="0 0 20 20" {...S}><path d="M10 2.5a5 5 0 0 0-5 5c0 3.6 5 10 5 10s5-6.4 5-10a5 5 0 0 0-5-5Z" /><circle cx={10} cy={7.3} r={1.6} /></svg>
+);
+const Bolt = () => (
+  <svg viewBox="0 0 20 20" {...S}><path d="M11 2 4 11h5l-1 7 7-9h-5l1-7Z" /></svg>
+);
+const Check = () => (
+  <svg viewBox="0 0 20 20" {...S}><path d="M4.5 10.5 8.5 14.5 15.5 6" /></svg>
+);
+const Alert = () => (
+  <svg viewBox="0 0 20 20" {...S}><path d="M10 3.5 2.8 16h14.4L10 3.5Z" /><path d="M10 8.5v3.5" /><circle cx={10} cy={14} r={0.6} fill="currentColor" /></svg>
+);
+const Trophy = () => (
+  <svg viewBox="0 0 20 20" {...S}><path d="M6 3h8v4a4 4 0 0 1-8 0V3Z" /><path d="M6 4H3.5v1.5A2.5 2.5 0 0 0 6 8M14 4h2.5v1.5A2.5 2.5 0 0 1 14 8M8 13h4M7.5 17h5M10 11v2" /></svg>
+);
+
+export function Tones() {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <GlyphTile tone="accent"><Pin /></GlyphTile>
+      <GlyphTile tone="success"><Check /></GlyphTile>
+      <GlyphTile tone="warning"><Bolt /></GlyphTile>
+      <GlyphTile tone="danger"><Alert /></GlyphTile>
+      <GlyphTile tone="neutral"><Pin /></GlyphTile>
+    </div>
+  );
+}
+
+export function DataColor() {
+  return (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <GlyphTile color="#f59e0b"><Trophy /></GlyphTile>
+      <GlyphTile color="#8b5cf6"><Trophy /></GlyphTile>
+      <GlyphTile color="#0ea5e9"><Bolt /></GlyphTile>
+    </div>
+  );
+}

--- a/.design-sync/previews/Group.tsx
+++ b/.design-sync/previews/Group.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Group, Row, GlyphTile, Switch } from '@misterbeardy/design-system';
+
+const S = { width: 13, height: 13, fill: 'none', stroke: 'currentColor', strokeWidth: 1.75, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const };
+const Ruler = () => <svg viewBox="0 0 20 20" {...S}><path d="M3 7h14v6H3zM6 7v3M9 7v4M12 7v3M15 7v4" /></svg>;
+const Thermo = () => <svg viewBox="0 0 20 20" {...S}><path d="M10 3.5a2 2 0 0 0-2 2v6.2a3 3 0 1 0 4 0V5.5a2 2 0 0 0-2-2Z" /></svg>;
+const Bolt = () => <svg viewBox="0 0 20 20" {...S}><path d="M11 2 4 11h5l-1 7 7-9h-5l1-7Z" /></svg>;
+const Map = () => <svg viewBox="0 0 20 20" {...S}><path d="M7.5 4 3 6v11l4.5-2 5 2 4.5-2V2l-4.5 2-5-2ZM7.5 4v11M12.5 6v11" /></svg>;
+
+const Frame = ({ children }: { children: any }) => (
+  <div style={{ background: 'var(--bg)', padding: 22, borderRadius: 16, maxWidth: 440 }}>{children}</div>
+);
+
+export function SettingsList() {
+  return (
+    <Frame>
+      <Group header="Units" footer="Applies to every trip, past and future.">
+        <Row glyph={<GlyphTile tone="accent"><Ruler /></GlyphTile>} label="Distance" value="Miles" chevron />
+        <Row glyph={<GlyphTile tone="neutral"><Thermo /></GlyphTile>} label="Temperature" value="°F" chevron />
+      </Group>
+    </Frame>
+  );
+}
+
+export function ToggleList() {
+  const [chargers, setChargers] = useState(true);
+  const [tolls, setTolls] = useState(false);
+  return (
+    <Frame>
+      <Group header="Map layers">
+        <Row
+          glyph={<GlyphTile tone="success"><Bolt /></GlyphTile>}
+          label="Show chargers"
+          trailing={<Switch checked={chargers} onChange={setChargers} label="Show chargers" />}
+        />
+        <Row
+          glyph={<GlyphTile tone="neutral"><Map /></GlyphTile>}
+          label="Avoid tolls"
+          trailing={<Switch checked={tolls} onChange={setTolls} label="Avoid tolls" />}
+        />
+      </Group>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,28 @@
+import { Input } from '@misterbeardy/design-system';
+
+export function Placeholder() {
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Input placeholder="Search trips…" />
+    </div>
+  );
+}
+
+export function Filled() {
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Input defaultValue="idrovewhere@example.com" />
+    </div>
+  );
+}
+
+export function Labeled() {
+  return (
+    <label style={{ display: 'block', maxWidth: 320 }}>
+      <span style={{ display: 'block', fontFamily: 'var(--font-display)', fontSize: 13, fontWeight: 500, color: 'var(--text-muted)', marginBottom: 6 }}>
+        Email
+      </span>
+      <Input type="email" placeholder="you@example.com" />
+    </label>
+  );
+}

--- a/.design-sync/previews/Row.tsx
+++ b/.design-sync/previews/Row.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Group, Row, GlyphTile, Switch } from '@misterbeardy/design-system';
+
+const S = { width: 13, height: 13, fill: 'none', stroke: 'currentColor', strokeWidth: 1.75, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const };
+const Ruler = () => <svg viewBox="0 0 20 20" {...S}><path d="M3 7h14v6H3zM6 7v3M9 7v4M12 7v3M15 7v4" /></svg>;
+const Bolt = () => <svg viewBox="0 0 20 20" {...S}><path d="M11 2 4 11h5l-1 7 7-9h-5l1-7Z" /></svg>;
+
+const Frame = ({ children }: { children: any }) => (
+  <div style={{ background: 'var(--bg)', padding: 20, borderRadius: 16, maxWidth: 420 }}>{children}</div>
+);
+
+export function ValueRows() {
+  return (
+    <Frame>
+      <Group>
+        <Row glyph={<GlyphTile tone="accent"><Ruler /></GlyphTile>} label="Distance" value="Miles" chevron />
+        <Row label="Temperature" value="°F" chevron />
+      </Group>
+    </Frame>
+  );
+}
+
+export function WithControl() {
+  const [on, setOn] = useState(true);
+  return (
+    <Frame>
+      <Group>
+        <Row
+          glyph={<GlyphTile tone="success"><Bolt /></GlyphTile>}
+          label="Charging"
+          sub="Default for new trips"
+          trailing={<Switch checked={on} onChange={setOn} label="Charging" />}
+        />
+      </Group>
+    </Frame>
+  );
+}
+
+export function Navigation() {
+  return (
+    <Frame>
+      <Group>
+        <Row label="Every trip" sub="546 mi total" chevron />
+      </Group>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/Segmented.tsx
+++ b/.design-sync/previews/Segmented.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Segmented } from '@misterbeardy/design-system';
+
+export function Range() {
+  const [v, setV] = useState('30d');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Segmented
+        label="Range"
+        value={v}
+        onChange={setV}
+        options={[
+          { value: '30d', label: '30 days' },
+          { value: '1y', label: 'Year' },
+          { value: 'all', label: 'All time' },
+        ]}
+      />
+    </div>
+  );
+}
+
+export function WithSublabels() {
+  const [v, setV] = useState('miles');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Segmented
+        label="Units"
+        value={v}
+        onChange={setV}
+        options={[
+          { value: 'miles', label: 'Miles', sub: 'imperial' },
+          { value: 'km', label: 'Kilometres', sub: 'metric' },
+        ]}
+      />
+    </div>
+  );
+}
+
+export function Small() {
+  const [v, setV] = useState('map');
+  return (
+    <div style={{ maxWidth: 260 }}>
+      <Segmented
+        size="sm"
+        label="View"
+        value={v}
+        onChange={setV}
+        options={[
+          { value: 'map', label: 'Map' },
+          { value: 'list', label: 'List' },
+        ]}
+      />
+    </div>
+  );
+}

--- a/.design-sync/previews/StatStrip.tsx
+++ b/.design-sync/previews/StatStrip.tsx
@@ -1,0 +1,37 @@
+import { Group, StatStrip, Row } from '@misterbeardy/design-system';
+
+const Frame = ({ children }: { children: any }) => (
+  <div style={{ background: 'var(--bg)', padding: 22, borderRadius: 16, maxWidth: 440 }}>{children}</div>
+);
+
+export function YearSummary() {
+  return (
+    <Frame>
+      <Group header="This year">
+        <StatStrip
+          stats={[
+            { label: 'Miles', value: '12,480', accent: true },
+            { label: 'Counties', value: '37' },
+            { label: 'Charging', value: '$412', sub: '-8%', subTone: 'success' },
+          ]}
+        />
+        <Row label="Every trip" chevron />
+      </Group>
+    </Frame>
+  );
+}
+
+export function TwoUp() {
+  return (
+    <Frame>
+      <Group header="Open quotes">
+        <StatStrip
+          stats={[
+            { label: 'Value', value: '$128.40', accent: true },
+            { label: 'Active', value: '3', sub: '+1', subTone: 'success' },
+          ]}
+        />
+      </Group>
+    </Frame>
+  );
+}

--- a/.design-sync/previews/StatTile.tsx
+++ b/.design-sync/previews/StatTile.tsx
@@ -1,0 +1,19 @@
+import { StatTile } from '@misterbeardy/design-system';
+
+export function Single() {
+  return (
+    <div style={{ maxWidth: 220 }}>
+      <StatTile label="Open quote value" value="$128.40" sub="3 active" accent />
+    </div>
+  );
+}
+
+export function Strip() {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10, maxWidth: 520 }}>
+      <StatTile label="Miles" value="12,480" accent />
+      <StatTile label="Counties" value="37" />
+      <StatTile label="Charging" value="$412" sub="-8%" />
+    </div>
+  );
+}

--- a/.design-sync/previews/Switch.tsx
+++ b/.design-sync/previews/Switch.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { Switch, Group, Row } from '@misterbeardy/design-system';
+
+export function States() {
+  const [a, setA] = useState(true);
+  const [b, setB] = useState(false);
+  return (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'center' }}>
+      <Switch checked={a} onChange={setA} label="On" />
+      <Switch checked={b} onChange={setB} label="Off" />
+      <Switch checked onChange={() => {}} disabled label="Locked on" />
+    </div>
+  );
+}
+
+export function InRow() {
+  const [on, setOn] = useState(true);
+  return (
+    <div style={{ background: 'var(--bg)', padding: 20, borderRadius: 16, maxWidth: 420 }}>
+      <Group>
+        <Row label="Show chargers" trailing={<Switch checked={on} onChange={setOn} label="Show chargers" />} />
+      </Group>
+    </div>
+  );
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ node_modules/
 proxmox_mcp.log
 status-cache.json
 *.tgz
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/guidelines/accent.md
+++ b/guidelines/accent.md
@@ -1,0 +1,17 @@
+---
+category: Colors
+---
+
+# Accent — the per-app colour slot
+
+The accent is a **slot**, not a fixed colour. Every consuming app overrides three tokens with its own hue; everything else in the system stays identical across the portfolio.
+
+| Token | Role | Default (iDroveWhere blue, H256) |
+|---|---|---|
+| `--accent` | Solid fill — primary buttons, active states, the one headline metric | `oklch(0.6 0.15 256)` |
+| `--accent-soft` | Tinted fill — soft buttons, accent chips (lower emphasis) | `oklch(0.95 0.03 256)` |
+| `--accent-text` | Readable accent text on soft/surface backgrounds | `oklch(0.42 0.15 256)` |
+
+- Apps set these from `app-registry.js` (`accentFor(hue, chroma)`) — the registry is the single source of truth, and the default in `tokens/colors.css` mirrors it exactly.
+- Dark mode has its own accent values (lighter L, slightly reduced chroma) — every token is themed.
+- **Reserve the accent for meaning:** the primary action, the active selection, the single hero number. Spread it across a screen and it stops signalling importance. Status colours (success/warning/danger) are separate and never overridden — see [status](status.md).

--- a/guidelines/grouped-list.md
+++ b/guidelines/grouped-list.md
@@ -1,0 +1,16 @@
+---
+category: Foundations
+---
+
+# Grouped lists — the default UX
+
+The grouped-list vocabulary (`Group` + `Row` + `GlyphTile` + `Segmented` + `Switch` + `StatStrip`) is how this system builds settings, summaries, and detail screens. Assemble it the way it's meant to be used, and follow these rules.
+
+- **Cards group, they don't decorate.** Related rows live in one `Group` card. The system is **flat — no shadow**; depth is the `--surface`/`--bg` contrast plus a 1px border. If a card looks like it's floating, fix the page background (`--bg`), don't add a shadow.
+- **One idea per row.** The reading order is glyph → label → value → chevron. A row that needs two sentences is two rows, or a row with a chevron into a screen.
+- **The tile carries colour, never the card surface.** `GlyphTile` is where colour lives: `tone` when colour means *state* (semantic status tokens), `color` when it means *data* (per-category hues). Keeping colour off surfaces is what keeps it meaningful.
+- **Hairlines inset to the label's leading edge** (`--row-inset`) so the list reads as tidy rather than a ladder of full-width rules — and the last separator is suppressed so the Group's own border closes the list. The inset is arithmetic on the default `--glyph-size` (23px); a custom tile size needs a matching `--row-inset`.
+- **The number is the hero, its label is furniture.** In `StatStrip`/`StatTile`, only **one** metric per screen sets `accent`, so the accent keeps meaning "this is the important number".
+- **Vibrancy is a signal, not a texture.** Translucency (`.material-glass`) is the one sanctioned elevation — a panel over live content — never decoration.
+
+The Group has no padding of its own — rows own their padding so separators can run edge to edge. Don't wrap rows in a padded div to "fix" spacing; it breaks the hairline inset.

--- a/guidelines/neutrals.md
+++ b/guidelines/neutrals.md
@@ -1,0 +1,19 @@
+---
+category: Colors
+---
+
+# Neutrals — the warm greyscale
+
+A warm (not blue-grey) neutral scale, tinted so surfaces read as calm paper rather than cold UI chrome. Six steps, from page background to ink, themed light and dark.
+
+| Token | Role | Light | Dark |
+|---|---|---|---|
+| `--bg` | Page background — **never pure white** | `#f6f5f3` | `#211f1c` |
+| `--surface` | Card / row / input surface | `#ffffff` | `#2a2723` |
+| `--surface-alt` | Recessed surface — segmented track, chips | `#f1ede6` | `#322f2a` |
+| `--border` | 1px hairline borders and dividers | `#e2ded7` | `#3a352f` |
+| `--border-soft` | Even quieter divider | `#f1ede6` | `#332f29` |
+| `--text-muted` | Secondary text, labels, values | `#6c675f` | `#a39c91` |
+| `--text-ink` | Primary text | `#1c1b19` | `#f3f1ed` |
+
+The whole system depends on `--bg` being tinted: a card is just `--surface` + a 1px `--border` sitting on `--bg`, and that contrast is the only depth there is (no shadows). Dark mode is `[data-theme="dark"]` on a root element.

--- a/guidelines/radius.md
+++ b/guidelines/radius.md
@@ -1,0 +1,16 @@
+---
+category: Spacing
+---
+
+# Radius — the corner scale
+
+| Token | Value | Used on |
+|---|---|---|
+| `--radius-sm` | 6px | `GlyphTile` |
+| `--radius-md` | 10px | Inputs, buttons, segmented track |
+| `--radius-lg` | 14px | `Card`, `StatTile` |
+| `--radius-xl` | 20px | Large panels |
+| `--radius-pill` | 9999px | `Chip`, `Switch` track |
+| `--radius-card` | 12px | The grouped `Group` card |
+
+`--radius-card` is **a role, not a step in the scale** — it's specifically the grouped-list card corner, sized to sit right with the inset rows. Use the named role tokens rather than picking a number, so corners stay consistent as the scale evolves.

--- a/guidelines/spacing.md
+++ b/guidelines/spacing.md
@@ -1,0 +1,18 @@
+---
+category: Spacing
+---
+
+# Spacing — a 4px base scale
+
+Six steps on a 4px base. Use the tokens for layout gaps and padding so rhythm stays consistent across apps.
+
+| Token | Value |
+|---|---|
+| `--space-1` | 4px |
+| `--space-2` | 8px |
+| `--space-3` | 12px |
+| `--space-4` | 16px |
+| `--space-5` | 24px |
+| `--space-6` | 32px |
+
+Reach for a token before a raw pixel value — `gap: var(--space-3)`, `padding: var(--space-5)`. Row and Group internal spacing is already handled by the components (`--row-gap`, `--row-pad-x`); you space the *layout around* them.

--- a/guidelines/status.md
+++ b/guidelines/status.md
@@ -1,0 +1,19 @@
+---
+category: Colors
+---
+
+# Status — success / warning / danger
+
+Semantic outcome colours, each in the same solid / soft / text structure as the accent slot. Unlike the accent, status tokens are **app-agnostic — never overridden**, so the same state reads identically across every app in the portfolio.
+
+| State | Solid | Soft (chip bg) | Text (on soft) | Use for |
+|---|---|---|---|---|
+| success | `--success` | `--success-soft` | `--success-text` | PAID, DONE, positive delta |
+| warning | `--warning` | `--warning-soft` | `--warning-text` | PENDING, LOW STOCK |
+| danger | `--danger` | `--danger-soft` | `--danger-text` | OVERDUE, FAILED |
+
+Light values: `success oklch(0.58 0.13 150)`, `warning oklch(0.64 0.13 80)`, `danger oklch(0.55 0.18 25)` (each with matching soft/text; all themed for dark).
+
+- Reach for status **only for real outcome states** — `accent`/`neutral` cover everything that isn't a genuine success/warning/danger. Don't use status tones decoratively.
+- The soft/text pair is the `Chip` recipe: `<Chip tone="success">PAID</Chip>`. The solid is for `GlyphTile tone=…` and `Switch` (on = `--success`).
+- Note: warning (H80) sits near some brand hues (H70–75) — a warning chip and an accent chip can look like siblings in those apps. Acceptable; both mean "attention".

--- a/guidelines/type-scale.md
+++ b/guidelines/type-scale.md
@@ -1,0 +1,25 @@
+---
+category: Type
+---
+
+# Type scale
+
+Two families: **Space Grotesk** (`--font-display`) for all UI copy, **JetBrains Mono** (`--font-mono`) for data — numbers, codes, status labels. Both load via a remote `@import` in `tokens/typography.css`.
+
+Use the `--text-*` shorthands (each packs weight/size/line-height/family) rather than setting font properties by hand.
+
+| Token | Spec | Role |
+|---|---|---|
+| `--text-display` | 700 38px Space Grotesk | Page hero |
+| `--text-heading` | 700 24px | Section heading |
+| `--text-subhead` | 600 17px | Subheading |
+| `--text-body` | 400 15px | Body copy (all UI text) |
+| `--text-label` | 500 11px JetBrains Mono | Mono label, uppercase |
+| `--text-section` | 600 10px mono | `Group` header (uppercase) |
+| `--text-row-label` | 400 13px | `Row` label |
+| `--text-row-sub` | 400 11px | `Row` sub-label |
+| `--text-row-value` | 400 12px mono | `Row` value (tabular) |
+| `--text-stat` | 700 19px | `StatStrip` number |
+| `--text-stat-label` | 400 9px mono | `StatStrip` label (uppercase) |
+
+Data (numbers, codes, deltas) goes in `--font-mono` with `font-variant-numeric: tabular-nums`; everything a person reads goes in `--font-display`. Pair mono values with `--tracking-caps` / `--tracking-stat` where the components already do.


### PR DESCRIPTION
First `/design-sync` import of the design system into the Claude Design project **lookwhatibuilt.today** (`38437aad-2039-4a1a-ad1d-73b3aeb3cec2`).

This commits only the **durable sync inputs** (under `.design-sync/`) so future re-syncs are fast and reproducible — build output, caches, and staged converter scripts stay gitignored.

## What's imported (server-side)
- **11 core components**, each with a richly authored, graded preview (no floor cards): Button, Card, Chip, Input, StatTile, Group, Row, GlyphTile, Segmented, Switch, StatStrip.
- Render check clean (11/11, 0 bad/thin); `package-validate` exits 0.
- Per-component `.d.ts` contracts + the repo's hand-authored `.prompt.md` docs (preserved via `docsMap`, not synthesized).
- A README conventions header teaching the agent the token idiom (no provider, no utility classes, tint the page `--bg`, grouped-list rules).

## Files in this PR
- `.design-sync/config.json` — component/doc maps, `cssEntry`/`tokensPkg` wiring, `Input` card override, `readmeHeader`.
- `.design-sync/conventions.md` — the README header (validated against built artifacts).
- `.design-sync/previews/*.tsx` — 11 authored preview compositions.
- `.design-sync/NOTES.md` — repo-specific setup gotchas + re-sync risks.
- `.gitignore` — ignores generated build/cache/script dirs.

## Re-sync notes
`NOTES.md` documents the per-clone setup (a `--no-save` react install and a `node_modules/@misterbeardy/design-system` self-symlink for token copying) and why `componentSrcMap`/`docsMap` are hand-enumerated (the package declares no `types` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)